### PR TITLE
Syntax highlighting for VIM

### DIFF
--- a/VIM/README.md
+++ b/VIM/README.md
@@ -1,0 +1,10 @@
+# [vim-kerboscript](https://github.com/tomvanderlee/vim-kerboscript)
+
+Syntax highlighting for kerboscript.
+
+## Instalation
+
+I recommend using a plugin manager like [pathogen](https://github.com/tpope/vim-pathogen) to install kerboscript.vim.
+
+    cd ~/.vim/bundle
+    git clone git://github.com/tomvanderlee/vim-kerboscript.git

--- a/VIM/README.md
+++ b/VIM/README.md
@@ -2,9 +2,21 @@
 
 Syntax highlighting for kerboscript.
 
-## Instalation
+## Installation
 
-I recommend using a plugin manager like [pathogen](https://github.com/tpope/vim-pathogen) to install kerboscript.vim.
+I recommend using a plugin manager like [pathogen](https://github.com/tpope/vim-pathogen) or [vundle](https://github.com/gmarik/Vundle.vim) to install kerboscript.vim.
+
+### Pathogen
+
+In ~/.vim/bundle clone git://github.com/tomvanderlee/vim-kerboscript.git
 
     cd ~/.vim/bundle
     git clone git://github.com/tomvanderlee/vim-kerboscript.git
+
+### Vundle
+
+Add tomvanderlee/vim-kerboscript to your `.vimrc`
+
+    Plugin 'tomvanderlee/vim-kerboscript'
+
+Launch `vim` and run `:PluginInstall`

--- a/VIM/placeholder.txt
+++ b/VIM/placeholder.txt
@@ -1,1 +1,0 @@
-This is the location of some cool highlighting rules.


### PR DESCRIPTION
The reason I only put up instructions on "how to install vim-kerboscript" instead of adding the code, is because installing plugins with a plugin manager is easier if the plugin is the root repository.