### PR TITLE
Updated VIM/README.md with correct Vundle string

### DIFF
--- a/VIM/README.md
+++ b/VIM/README.md
@@ -17,7 +17,7 @@ In ~/.vim/bundle download the VIM subdirectory with svn
 
 Add VIM/vim-kerboscript to your `.vimrc`
 
-    Plugin 'VIM/vim-kerboscript'
+    Plugin 'KSP-KOS/EditorTools', {'rtp': 'VIM/vim-kerboscript'}
 
 Launch `vim` and run `:PluginInstall`
 


### PR DESCRIPTION
The Vundle plugin string was incorrect, since for GitHub repos it should be in the following format:
`Plugin 'repo_user/repo_name'`

Since the vim plugin is in the `VIM/vim-kerboscript` subdirectory, we need to add the runtimepath as an option to the plugin command instead of in the string.